### PR TITLE
Usability fixes

### DIFF
--- a/src/components/cells/CellNode.tsx
+++ b/src/components/cells/CellNode.tsx
@@ -54,7 +54,8 @@ export function CellNode({
           ? 'rgb(195, 235, 202)'
           : 'rgb(229,252,233)',
         borderRadius: '5px',
-        padding: '10px'
+        padding: '10px',
+        cursor: 'move'
       }}
     >
       <span

--- a/src/components/cells/CellPopup.tsx
+++ b/src/components/cells/CellPopup.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Paper from '@mui/material/Paper';
 import { useClickOutside } from '@mantine/hooks';
 
@@ -16,11 +16,12 @@ export function CellPopup({
   cellNode: HTMLDivElement | null;
   onClose: () => void;
 }) {
-  const ref = useClickOutside(onClose, null, [cellNode]);
+  const [ref, setRef] = useState<HTMLElement | null>(null);
+  useClickOutside(onClose, null, [ref, cellNode]);
 
   return (
     <Paper
-      ref={ref}
+      ref={setRef}
       elevation={12}
       sx={{
         position: 'absolute',

--- a/src/components/common/CellInfo.tsx
+++ b/src/components/common/CellInfo.tsx
@@ -67,7 +67,9 @@ export function CellInfo({ cell }: { cell: ICell }) {
   return (
     <Box sx={{ margin: '15px' }}>
       <PropsTable>
-        <PropsTableRow cells={['Image name', cell.container_image]} />
+        {cell.container_image && (
+          <PropsTableRow cells={['Image name', cell.container_image]} />
+        )}
         {cell.base_container_image && (
           <>
             <PropsTableRow

--- a/src/components/common/CellInfo.tsx
+++ b/src/components/common/CellInfo.tsx
@@ -86,7 +86,9 @@ export function CellInfo({ cell }: { cell: ICell }) {
           <PropsTableRow
             cells={[
               'Source',
-              <Link href={cell.source_url}>{cell.source_url}</Link>
+              <Link href={cell.source_url} target="_blank" rel="noreferrer">
+                {cell.source_url}
+              </Link>
             ]}
           />
         )}


### PR DESCRIPTION
- Open cell source URL in new tab (#5)
- Show move cursor on hover in cells list to make it obvious that cells can be dragged and dropped 

  ![image](https://github.com/user-attachments/assets/d3d38ad2-1185-4e94-b221-82c0dfffdceb)
- Hide empty image name in special cells popup

  ![image](https://github.com/user-attachments/assets/a8030380-b22d-4d5f-8da5-9f0365e90d35)
- Fix bug introduced in 7505c53 that preventing clicking inside the cell info popup 