### PR TITLE
Loosen dependency requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "NaaVRE-communicator-jupyterlab~=0.3.0"
+    "NaaVRE-communicator-jupyterlab>=0.3.0"
 ]
 dynamic = ["version", "description", "authors", "urls", "keywords"]
 


### PR DESCRIPTION
To avoid the following error when installing NaaVRE-containerizer-jupyterlab and NaaVRE-workflow-jupyterlab together:

```
The conflict is caused by:
    The user requested NaaVRE-communicator-jupyterlab==0.3.0
    naavre-containerizer-jupyterlab 0.4.0 depends on naavre-communicator-jupyterlab~=0.2.3
```